### PR TITLE
Update the vxr pattern to match spitfire/linux

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -870,8 +870,8 @@ class BaseConnection(object):
         time.sleep(delay_factor * 0.1 )
         # Initial attempt to get prompt
         prompt = self.read_channel()
-        vxr_pattern = "Last Login"
-        if vxr_pattern in prompt:
+        vxr_pattern = "last login"
+        if vxr_pattern in prompt.lower():
             time.sleep((delay_factor * 0.1)+3)
             prompt = self.read_channel()
         if self.ansi_escape_codes:


### PR DESCRIPTION
was hitting the "can't find prompt issue" testing spitfire sanity and so created a new environment with this change to test it out. Logs with that env can be found [here](http://cafy-jk-lnx:8080/job/bit_exec_pytest/39/consoleFull)
