### PR TITLE
Commit returns 'None' on failed config with commit_error_dialog_dict set

### DIFF
--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -200,6 +200,8 @@ class CiscoXr(CiscoBaseConnection):
                         output += self.send_command_timing(marker_value, strip_prompt=False, strip_command=False,
                                                                delay_factor=delay_factor)
                         return output
+                    else:
+                        raise err
                 elif alt_error_marker in output:
                     # Other commits occurred, don't proceed with commit
                     output += self.send_command_timing("no", strip_prompt=False, strip_command=False,


### PR DESCRIPTION
The problem comes when “if commit_error_dialog_dict is not None and alt_error_marker in commit_error_dialog_dict” case is hit, but then “if alt_error_marker in output:” is not hit – in the case where there was a commit error which is not the 'One or more commits have occurred from other' error.
 
If this path is hit, there is no ‘else’ case, so no output is returned and also no exception raised – i.e. there’s no way to tell anything about the commit result.
