### PR TITLE
Addressing unpredictable delay after RP switchover

### DIFF
--- a/netmiko/base_connection.py
+++ b/netmiko/base_connection.py
@@ -918,10 +918,6 @@ class BaseConnection(object):
         if autocommand_pattern in prompt.lower():
             time.sleep((delay_factor * 0.1)+5)
             prompt=self.read_channel()
-        cxr_pattern = "last switch-over"
-        if cxr_pattern in prompt.lower():
-            time.sleep((delay_factor * 0.1)+3)
-            prompt = self.read_channel()        
         if self.ansi_escape_codes:
             prompt = self.strip_ansi_escape_codes(prompt)
 
@@ -938,6 +934,12 @@ class BaseConnection(object):
                 self.write_channel(self.RETURN)
                 time.sleep(delay_factor * .1)
             count += 1
+
+        # Delay after RP switchover
+        cxr_pattern = "last switch-over"
+        if cxr_pattern in prompt.lower():
+            time.sleep((delay_factor * 0.1)+3)
+            prompt += self.read_channel()
 
         # If multiple lines in the output take the last line
         prompt = self.normalize_linefeeds(prompt)


### PR DESCRIPTION
The initial proposed fix works on the first observed issue which is due to delay between “last switch-over” and prompt.. So introduced delay in-between; Though in other occurrences, the first read itself results upto prompt; or till the last read channel, only empty lines read, so the script fails leaving the prompt in channel unread. These delays are unpredictable. 
So placed the check at right place now and tested. 

Fail Logs:
http://allure.cisco.com/ws/msuralik-bgl/star_data/smart/logs/star_main_20200106-174259_p24789/allure/data/292da3d7-361e-469d-920e-39755408febe-attachment.html

Pass Logs:
http://allure.cisco.com/ws/msuralik-bgl/star_data/smart/logs/star_main_20200107-184000_p1180/allure/data/c41538f9-884a-46cd-9e84-909e8c6edd4d-attachment.html
 