### PR TITLE
changed send_command_timing to send_command_expect

### DIFF
--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -186,8 +186,8 @@ class CiscoXr(CiscoBaseConnection):
                                                delay_factor=delay_factor)
             commit_replace_marker = "This commit will replace or remove the entire running configuration"
             if commit_replace_marker in output:
-                output += self.send_command_timing("yes", strip_prompt=False, strip_command=False,
-                                                   delay_factor=delay_factor)
+                output += self.send_command_expect("yes", strip_prompt=False, strip_command=False,
+                                                   delay_factor=delay_factor, **kwargs)
                 return output
                                    
         else: 

--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -171,10 +171,10 @@ class CiscoXr(CiscoBaseConnection):
             command_string = 'commit comment {0}'.format(comment)
         else:
             command_string = 'commit'
-        if best_effort:
-            command_string = command_string.replace("commit","commit best-effort")
         if force:
             command_string = command_string.replace("commit","commit force")
+        if best_effort:
+            command_string = command_string.replace("commit","commit best-effort")
         if replace:
             command_string = command_string.replace("commit","commit replace")
         print("command string is ",command_string)

--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -187,7 +187,7 @@ class CiscoXr(CiscoBaseConnection):
             commit_replace_marker = "This commit will replace or remove the entire running configuration"
             if commit_replace_marker in output:
                 if 'expect_string' in kwargs:
-                    kwargs['expect_string'] = r')#'
+                    kwargs['expect_string'] = r'\)#'
                 output += self.send_command_expect("yes", strip_prompt=False, strip_command=False,
                                                    delay_factor=delay_factor, **kwargs)
                 return output

--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -187,7 +187,7 @@ class CiscoXr(CiscoBaseConnection):
             commit_replace_marker = "This commit will replace or remove the entire running configuration"
             if commit_replace_marker in output:
                 output += self.send_command_expect("yes", strip_prompt=False, strip_command=False,
-                                                   delay_factor=delay_factor, **kwargs)
+                                                   delay_factor=delay_factor, expect_string=')#',**kwargs)
                 return output
                                    
         else: 

--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -187,7 +187,7 @@ class CiscoXr(CiscoBaseConnection):
             commit_replace_marker = "This commit will replace or remove the entire running configuration"
             if commit_replace_marker in output:
                 if 'expect_string' in kwargs:
-                    kwargs['expect_string'] = ')#'
+                    kwargs['expect_string'] = r')#'
                 output += self.send_command_expect("yes", strip_prompt=False, strip_command=False,
                                                    delay_factor=delay_factor, **kwargs)
                 return output

--- a/netmiko/cisco/cisco_xr.py
+++ b/netmiko/cisco/cisco_xr.py
@@ -186,8 +186,10 @@ class CiscoXr(CiscoBaseConnection):
                                                delay_factor=delay_factor)
             commit_replace_marker = "This commit will replace or remove the entire running configuration"
             if commit_replace_marker in output:
+                if 'expect_string' in kwargs:
+                    kwargs['expect_string'] = ')#'
                 output += self.send_command_expect("yes", strip_prompt=False, strip_command=False,
-                                                   delay_factor=delay_factor, expect_string=')#',**kwargs)
+                                                   delay_factor=delay_factor, **kwargs)
                 return output
                                    
         else: 


### PR DESCRIPTION
The objective is to pass commit replace <> cmd to send_command_expect() instead of send_command_timing() which does not wait for prompt, it just issues the cmd, waits until the given timeout and returns. 
send_command_expect() waits for the expected prompt until the given timeout.

allure.cisco.com/ws/shreyash-sjc/cafyinfra/cafykit/work/archive/test_commit_replace_20210322-203228_p40223/reports/index.html
