### PR TITLE
BSP: introduction of bsp as an os_type and methods for telnet/console/ssh connectivity

### DIFF
--- a/netmiko/cisco/__init__.py
+++ b/netmiko/cisco/__init__.py
@@ -5,6 +5,7 @@ from netmiko.cisco.cisco_asa_ssh import CiscoAsaSSH, CiscoAsaFileTransfer
 from netmiko.cisco.cisco_nxos_ssh import CiscoNxosSSH, CiscoNxosFileTransfer
 from netmiko.cisco.cisco_xr import CiscoXrSSH, CiscoXrTelnet, CiscoCxrHa, CiscoXrFileTransfer
 from netmiko.cisco.cisco_cloudnative import CiscoCloudnativeSSH, CiscoCloudnativeTelnet
+from netmiko.cisco.cisco_bsp import CiscoBspSSH, CiscoBspTelnet
 from netmiko.cisco.cisco_wlc_ssh import CiscoWlcSSH
 from netmiko.cisco.cisco_s300 import CiscoS300SSH
 from netmiko.cisco.cisco_tp_tcce import CiscoTpTcCeSSH
@@ -13,4 +14,4 @@ __all__ = ['CiscoIosSSH', 'CiscoIosTelnet', 'CiscoAsaSSH', 'CiscoNxosSSH', 'Cisc
            'CiscoXrTelnet', 'CiscoWlcSSH', 'CiscoS300SSH', 'CiscoTpTcCeSSH', 'CiscoIosBase',
            'CiscoIosFileTransfer', 'InLineTransfer', 'CiscoAsaFileTransfer',
            'CiscoNxosFileTransfer', 'CiscoIosSerial', 'CiscoXrFileTransfer',
-           'CiscoCloudnativeSSH', 'CiscoCloudnativeTelnet']
+           'CiscoCloudnativeSSH', 'CiscoCloudnativeTelnet','CiscoBspSSH','CiscoBspTelnet']

--- a/netmiko/cisco/cisco_bsp.py
+++ b/netmiko/cisco/cisco_bsp.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from netmiko.cisco_base_connection import CiscoBaseConnection
+
+class CiscoBsp(CiscoBaseConnection):
+    '''
+    CiscoBsp is based of CiscoBaseConnection
+    '''
+    pass
+
+class CiscoBspSSH(CiscoBsp):
+    '''
+    CiscoBspSSH is based of CiscoBsp -- CiscoBaseConnection
+    '''
+
+    pass
+
+class CiscoBspTelnet(CiscoBsp):
+    '''
+    CiscoBspTelnet is based of CiscoBsp -- CiscoBaseConnection
+    '''
+
+    pass

--- a/netmiko/cisco/cisco_bsp.py
+++ b/netmiko/cisco/cisco_bsp.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from logger.cafylog import CafyLog
 from netmiko.cisco_base_connection import CiscoBaseConnection
+from netmiko.ssh_exception import NetMikoAuthenticationException
 import re
 import time
 

--- a/netmiko/cisco/cisco_bsp.py
+++ b/netmiko/cisco/cisco_bsp.py
@@ -1,13 +1,141 @@
 from __future__ import print_function
 from __future__ import unicode_literals
-
+from logger.cafylog import CafyLog
 from netmiko.cisco_base_connection import CiscoBaseConnection
+import re
+import time
+
+log = CafyLog()
 
 class CiscoBsp(CiscoBaseConnection):
     '''
     CiscoBsp is based of CiscoBaseConnection
     '''
-    pass
+    def bmc_to_bsp_prompt(self,bmc_prompt_pattern=r'\s*\#',bsp_prompt_pattern=r']\s*\#',delay_factor=1,max_loops=20):
+
+        self.TELNET_RETURN = '\n'
+        bmc_to_bsp_cmd = "sol.sh"
+        delay_factor = self.select_delay_factor(delay_factor)
+
+        i = 1
+        while i <= max_loops:
+            i += 1
+            output = self.find_prompt()
+            if re.search(bmc_prompt_pattern, output):
+                log.debug("On BMC Prompt")
+                log.debug("Sol.sh to enter BSP prompt")
+                self.write_channel(bmc_to_bsp_cmd)
+                time.sleep(1 * delay_factor)
+                self.write_channel(self.TELNET_RETURN)
+                time.sleep(1 * delay_factor)
+                output = self.find_prompt()
+
+            if re.search(bsp_prompt_pattern, output):
+                log.debug("On BSP Prompt")
+                return
+
+    def bsp_to_bmc_prompt(self,bmc_prompt_pattern=r'\s*\#',bsp_prompt_pattern=r']\s*\#',delay_factor=1, max_loops=20):
+
+        self.TELNET_RETURN = '\n'
+        CTRL_L = "\x0c"
+        delay_factor = self.select_delay_factor(delay_factor)
+
+        i = 1
+        while i <= max_loops:
+            i += 1
+            output = self.find_prompt()
+            if re.search(bsp_prompt_pattern, output):
+                log.debug("On BSP Prompt")
+                log.debug("Ctrl + L; press X to enter BMC prompt")
+                self.write_channel(CTRL_L)
+                time.sleep(1 * delay_factor)
+                self.write_channel('x'+self.TELNET_RETURN)
+                time.sleep(1 * delay_factor)
+                output = self.find_prompt()
+
+            if re.search(bmc_prompt_pattern, output):
+                log.debug("On BMC Prompt")
+                return
+
+    def bmc_login(self,prompt_pattern=r'\s*\#',username_pattern='login',pwd_pattern=r'assword',delay_factor=1, max_loops=20):
+
+        bmc_username = "root"
+        bmc_pass = "0penBmc"
+        self.TELNET_RETURN = '\n'
+
+        i = 1
+        while i <= max_loops:
+            i += 1
+            output = self.find_prompt()
+
+            log.debug("Check if we are already on BMC prompt")
+            if re.search(prompt_pattern, output):
+                log.debug("On BMC Prompt")
+                return
+
+            log.debug("Check if BMC Username Prompt detected")
+            if re.search(username_pattern, output):
+                log.debug("BMC Username pattern detected, sending Username={}".format(bmc_username))
+                time.sleep(1)
+                self.write_channel(bmc_username)
+                time.sleep(1 * delay_factor)
+                output = self.find_prompt()
+
+            log.debug("Check if BMC Password Prompt detected")
+            if re.search(pwd_pattern, output):
+                log.debug("BMC Password pattern detected, sending Password={}".format(bmc_pass))
+                self.write_channel(bmc_pass)
+                time.sleep(.5 * delay_factor)
+                output = self.find_prompt()
+
+                if re.search(prompt_pattern, output):
+                    log.debug("On BMC Prompt")
+                    return
+
+                if re.search(pwd_pattern, output):
+                    self.write_channel(bmc_pass)
+                    time.sleep(.5 * delay_factor)
+
+        # Last try to see if we already logged in
+        self.write_channel(self.TELNET_RETURN)
+        time.sleep(.5 * delay_factor)
+        output = self.find_prompt()
+        if re.search(prompt_pattern, output):
+            log.debug("On BMC Prompt")
+            return
+
+        raise NetMikoAuthenticationException("LAST_TRY login failed for BMC Prompt")
+
+    def set_base_prompt(self, pri_prompt_terminator='#',alt_prompt_terminator='$', delay_factor=1):
+        """Sets self.base_prompt
+
+        Used as delimiter for stripping of trailing prompt in output.
+
+        Should be set to something that is general and applies in multiple contexts. For Cisco
+        devices this will be set to router hostname (i.e. prompt without '>' or '#').
+
+        This will be set on entering user exec or privileged exec on Cisco, but not when
+        entering/exiting config mode.
+
+        :param pri_prompt_terminator: Primary trailing delimiter for identifying a device prompt
+        :type pri_prompt_terminator: str
+
+        :param alt_prompt_terminator: Alternate trailing delimiter for identifying a device prompt
+        :type alt_prompt_terminator: str
+
+        :param delay_factor: See __init__: global_delay_factor
+        :type delay_factor: int
+        """
+        prompt = self.find_prompt(delay_factor=delay_factor)
+        if not prompt[-1] in (pri_prompt_terminator, alt_prompt_terminator):
+            raise ValueError("BSP prompt not found: {0}".format(repr(prompt)))
+        # Strip off trailing terminator
+        self.base_prompt = prompt[:-1]
+        return self.base_prompt
+
+    def disable_paging(self, *args, **kwargs):
+        """Paging is disabled by default."""
+        return ""
 
 class CiscoBspSSH(CiscoBsp):
     '''
@@ -21,4 +149,95 @@ class CiscoBspTelnet(CiscoBsp):
     CiscoBspTelnet is based of CiscoBsp -- CiscoBaseConnection
     '''
 
-    pass
+    def telnet_login(self,pri_prompt_terminator=r']\s*\#',alt_prompt_terminator=r']\s*\$',username_pattern=r'login',pwd_pattern=r'assword',delay_factor=1,max_loops=20):
+        self.TELNET_RETURN = '\n'
+        delay_factor = self.select_delay_factor(delay_factor)
+        time.sleep(1 * delay_factor)
+        my_username = self.username
+        my_password = self.password
+        return_msg = ''
+        i = 1
+        while i <= max_loops:
+            try:
+                # self.read_channel which internally calls telnetlib.read_ver_eager() returns empty string
+                log.debug("Reading channel for the first time")
+                output = self.read_channel()
+
+                # self.find_prompt will return prompt after logging in
+                log.debug("Output after reading channel for first time: {}".format(output))
+                if output == '':
+                    time.sleep(2 * delay_factor)
+                    log.debug("output is empty, doing find_prompt()")
+                    output = self.find_prompt()
+                    log.debug("Output after doing find_prompt: {}".format(output))
+                    return_msg += output
+
+                log.debug("Checking if Password Prompt")
+                if re.search(pwd_pattern, output):
+                    log.debug("Differentiate whether it is password prompt for BMC or BSP")
+                    self.write_channel(self.TELNET_RETURN)
+                    output = self.find_prompt()
+                    return_msg += output
+
+                log.debug("Checking if BMC prompt")
+                if 'bmc' in output:
+                    log.debug("BMC Login prompt detected")
+                    self.bmc_login()
+                    time.sleep(2 * delay_factor)
+                    self.bmc_to_bsp_prompt()
+                    time.sleep(2 * delay_factor)
+                    output = self.find_prompt()
+                    return_msg += output
+
+                log.debug("Searching for username pattern")
+                if re.search(username_pattern, output):
+                    log.debug("Username pattern detected, sending Username={}".format(my_username))
+                    time.sleep(1)
+                    self.write_channel(my_username + self.TELNET_RETURN)
+                    time.sleep(1 * delay_factor)
+                    output = self.read_channel()
+                    return_msg += output
+                    log.debug("After sending username, the output pattern is={}".format(output))
+
+                log.debug("Searching for password pattern")
+                if re.search(pwd_pattern, output):
+                    self.write_channel(my_password + self.TELNET_RETURN)
+                    time.sleep(.5 * delay_factor)
+                    output = self.read_channel()
+                    return_msg += output
+
+                    if re.search(pri_prompt_terminator, output, flags=re.M) or re.search(alt_prompt_terminator, output,flags=re.M):
+                        return return_msg
+
+                    if re.search(pwd_pattern, output):
+                        self.write_channel(my_password + self.TELNET_RETURN)
+                        time.sleep(.5 * delay_factor)
+                        output = self.read_channel()
+                        return_msg += output
+
+                # Check for device with no password configured
+                if re.search(r"assword required, but none set", output):
+                    msg = "Telnet login failed - Password required, but none set: {}".format(self.host)
+                    raise NetMikoAuthenticationException(msg)
+
+                # Check if already on BSP prompt
+                if re.findall(pri_prompt_terminator, output) or re.findall(alt_prompt_terminator, output):
+                    return return_msg
+
+                self.write_channel(self.TELNET_RETURN)
+                time.sleep(.5 * delay_factor)
+                i += 1
+            except EOFError:
+                msg = "EOFError Telnet login failed: {0}".format(self.host)
+                raise NetMikoAuthenticationException(msg)
+
+        # Last try to see if we already logged in
+        self.write_channel(self.TELNET_RETURN)
+        time.sleep(.5 * delay_factor)
+        output = self.read_channel()
+        return_msg += output
+        if (re.search(pri_prompt_terminator, output, flags=re.M) or re.search(alt_prompt_terminator, output,flags=re.M)):
+            return return_msg
+
+        msg = "LAST_TRY Telnet login failed: {0}".format(self.host)
+        raise NetMikoAuthenticationException(msg)

--- a/netmiko/cisco/cisco_bsp.py
+++ b/netmiko/cisco/cisco_bsp.py
@@ -12,6 +12,15 @@ class CiscoBsp(CiscoBaseConnection):
     CiscoBsp is based of CiscoBaseConnection
     '''
     def bmc_to_bsp_prompt(self,bmc_prompt_pattern=r'\s*\#',bsp_prompt_pattern=r']\s*\#',delay_factor=1,max_loops=20):
+        '''
+        Switch from BMC to BSP prompt
+
+        :param bmc_prompt_pattern: expected BMC prompt
+        :param bsp_prompt_pattern: expected BSP prompt
+        :param delay_factor: Factor to adjust delays
+        :param max_loops: max number of iterations for attempting to switch prompts
+        :return:
+        '''
 
         self.TELNET_RETURN = '\n'
         bmc_to_bsp_cmd = "sol.sh"
@@ -35,6 +44,15 @@ class CiscoBsp(CiscoBaseConnection):
                 return
 
     def bsp_to_bmc_prompt(self,bmc_prompt_pattern=r'\s*\#',bsp_prompt_pattern=r']\s*\#',delay_factor=1, max_loops=20):
+        '''
+        Switch from BSP to BMC prompt
+
+        :param bmc_prompt_pattern: expected BMC prompt
+        :param bsp_prompt_pattern: expected BSP prompt
+        :param delay_factor: Factor to adjust delays
+        :param max_loops: max number of iterations for attempting to switch prompts
+        :return:
+        '''
 
         self.TELNET_RETURN = '\n'
         CTRL_L = "\x0c"
@@ -58,6 +76,16 @@ class CiscoBsp(CiscoBaseConnection):
                 return
 
     def bmc_login(self,prompt_pattern=r'\s*\#',username_pattern='login',pwd_pattern=r'assword',delay_factor=1, max_loops=20):
+        '''
+        Handle BMC login prompt
+
+        :param prompt_pattern: expected BMC prompt
+        :param username_pattern: username prompt pattern
+        :param pwd_pattern: password prompt pattern
+        :param delay_factor: Factor to adjust delays
+        :param max_loops: max number of iterations for attempting to login to BMC prompt before raising exception
+        :return:
+        '''
 
         bmc_username = "root"
         bmc_pass = "0penBmc"
@@ -150,6 +178,18 @@ class CiscoBspTelnet(CiscoBsp):
     '''
 
     def telnet_login(self,pri_prompt_terminator=r']\s*\#',alt_prompt_terminator=r']\s*\$',username_pattern=r'login',pwd_pattern=r'assword',delay_factor=1,max_loops=20):
+        '''
+        Telnet login to BSP prompt
+
+        :param pri_prompt_terminator: primary prompt pattern (for root user)
+        :param alt_prompt_terminator: alternate prompt pattern (for non-root user eg: cisco user)
+        :param username_pattern: username prompt pattern
+        :param pwd_pattern: password prompt pattern
+        :param delay_factor: Factor to adjust delays
+        :param max_loops: max number of iterations for attempting to login to BSP prompt before raising exception
+        :return:
+        '''
+
         self.TELNET_RETURN = '\n'
         delay_factor = self.select_delay_factor(delay_factor)
         time.sleep(1 * delay_factor)

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -86,7 +86,7 @@ CLASS_MAPPER_BASE = {
     'cisco_xe': CiscoIosSSH,
     'cisco_xr': CiscoXrSSH,
     'cisco_cloudnative': CiscoCloudnativeSSH,
-    'cisco_bsp_ssh': CiscoBspSSH,
+    'cisco_bsp': CiscoBspSSH,
     'cisco_bsp_telnet': CiscoBspTelnet,
     'cisco_xr_telnet': CiscoXrTelnet,
     'cisco_cxr_ha_telnet': CiscoCxrHa,

--- a/netmiko/ssh_dispatcher.py
+++ b/netmiko/ssh_dispatcher.py
@@ -24,6 +24,7 @@ from netmiko.cisco import CiscoTpTcCeSSH
 from netmiko.cisco import CiscoWlcSSH
 from netmiko.cisco import CiscoXrSSH, CiscoXrFileTransfer
 from netmiko.cisco import CiscoCloudnativeSSH
+from netmiko.cisco import CiscoBspSSH, CiscoBspTelnet
 from netmiko.cisco import CiscoXrTelnet
 from netmiko.cisco import CiscoCxrHa
 from netmiko.citrix import NetscalerSSH
@@ -85,6 +86,8 @@ CLASS_MAPPER_BASE = {
     'cisco_xe': CiscoIosSSH,
     'cisco_xr': CiscoXrSSH,
     'cisco_cloudnative': CiscoCloudnativeSSH,
+    'cisco_bsp_ssh': CiscoBspSSH,
+    'cisco_bsp_telnet': CiscoBspTelnet,
     'cisco_xr_telnet': CiscoXrTelnet,
     'cisco_cxr_ha_telnet': CiscoCxrHa,
     'cisco_xe_telnet': CiscoIosTelnet,


### PR DESCRIPTION
New file introduced under netmiko/cisco folder - cisco_bsp.py

**Hierarchy:**
class CiscoBsp(CiscoBaseConnection)
class CiscoBspSSH(CiscoBsp)
class CiscoBspTelnet(CiscoBsp)

**BSP classes introduction:**
Changes made in netmiko/cisco/__init__.py and netmiko/ssh_dispatcher.py. 
Cafykit will send device_type = 'cisco_bsp' or 'cisco_bsp_telnet' and based on that correct BSP class will be invoked 

**Following scenarios need to be handled during BSP login**
1. Telnet login and we directly land on BSP prompt
2. Telnet login and we land on BSP Enter Username prompt
3. Telnet login and we land on BSP Enter Password prompt
4. Telnet login and we land on BMC prompt
5. Telnet login and we land on BMC Enter Username prompt
6. Telnet login and we land on BMC Enter Password prompt
7. Telnet login and Credentials are incorrect
8. Telnet login and system had just booted up 

**Methods implemented to handle above scenarios**
1. bmc_to_bsp_prompt() and bsp_to_bmc_prompt(): if we land up on BMC prompt, then we need to switch to BSP prompt. Similarly method implemented for vice-versa prompt switching as well.
2. bmc_login(): if we land up on BMC login prompt, enter the well known username and password to enter BMC prompt
3. set_base_prompt(): same as method implemented in base_connection.py with the only difference in alt_prompt_terminator.
4. telnet_login(): method implemented under CiscoBspTelnet and all the login scenarios handled over here by calling above methods

**Tried Scenarios:-**

**1. Switching between prompts**

(Pdb) output = self.find_prompt()
(Pdb) output
'root@bmc-oob:~#'

(Pdb) self.bmc_to_bsp_prompt()
-Debug----2022-05-16T17-14-16[MainThread][None]> On BMC Prompt
-Debug----2022-05-16T17-14-16[MainThread][None]> Sol.sh to enter BSP prompt
-Debug----2022-05-16T17-14-18[MainThread][None]> On BSP Prompt
(Pdb) output = self.find_prompt()
(Pdb) output
'[root@sw ~\]#'

(Pdb) self.bsp_to_bmc_prompt()
-Debug----2022-05-16T17-14-34[MainThread][None]> On BSP Prompt
-Debug----2022-05-16T17-14-34[MainThread][None]> Ctrl + L; press X to enter BMC prompt
-Debug----2022-05-16T17-14-37[MainThread][None]> On BMC Prompt

(Pdb) output = self.find_prompt()
(Pdb) output
'root@bmc-oob:~#'

**2. Login to BMC prompt**

(Pdb) output = self.find_prompt()
(Pdb) output
'bmc-oob login:'

(Pdb) self.bmc_login()
-Debug----2022-05-16T17-17-00[MainThread][None]> Check if we are already on BMC prompt
-Debug----2022-05-16T17-17-00[MainThread][None]> Check if BMC Username Prompt detected
-Debug----2022-05-16T17-17-00[MainThread][None]> BMC Username pattern detected, sending Username=root
-Debug----2022-05-16T17-17-03[MainThread][None]> Check if BMC Password Prompt detected
-Debug----2022-05-16T17-17-03[MainThread][None]> BMC Password pattern detected, sending Password=0penBmc
-Debug----2022-05-16T17-17-07[MainThread][None]> On BMC Prompt
(Pdb) output = self.find_prompt()
(Pdb) output
'root@bmc-oob:~#'

**3. Netmiko Side handling done completely and control passed back to cafykit**

uut.connect()
-- control passed from cafykit to netmiko

-Info-----2022-05-17T08-42-34[MainThread][WASP-SANJAY]> WASP-SANJAY: Connecting to device via: console
-Debug----2022-05-17T08-42-34[MainThread][HaConnection]> global_delay_factor used for connect function is: 3
-Info-----2022-05-17T08-42-34[MainThread][HaConnection]> connecting.. console 172.27.112.157 2015 root cisco123
-Debug----2022-05-17T08-42-37[MainThread][None]> Reading channel for the first time
-Debug----2022-05-17T08-42-37[MainThread][None]> Output after reading channel for first time:
-Debug----2022-05-17T08-42-43[MainThread][None]> output is empty, doing find_prompt()
-Debug----2022-05-17T08-42-44[MainThread][None]> Output after doing find_prompt: sw login:
-Debug----2022-05-17T08-42-44[MainThread][None]> Checking if Password Prompt
-Debug----2022-05-17T08-42-44[MainThread][None]> Checking if BMC prompt
-Debug----2022-05-17T08-42-44[MainThread][None]> Searching for username pattern
-Debug----2022-05-17T08-42-44[MainThread][None]> Username pattern detected, sending Username=root
-Debug----2022-05-17T08-42-48[MainThread][None]> After sending username, the output pattern is=root
Password:
-Debug----2022-05-17T08-42-48[MainThread][None]> Searching for password pattern
-> /ws/sinatesa-sjc/netmiko/cafykit/sidchanges/lib/python3.6/site-packages/netmiko-2.1.1-py3.6.egg/netmiko/base_connection.py(202)__init__()->None
-> import pdb;pdb.set_trace()

(Pdb) n
-> /ws/sinatesa-sjc/netmiko/cafykit/sidchanges/lib/python3.6/site-packages/netmiko-2.1.1-py3.6.egg/netmiko/ssh_dispatcher.py(190)ConnectHandler()-><netmiko.cisc...x7f0d208c7c18>
-> return ConnectionClass(*args, **kwargs)

(Pdb) n
-> /ws/sinatesa-sjc/netmiko/cafykit/lib/topology/connection/haconnection.py(141)_connect()
-> if 'RP Node is not ready' in nm_obj.base_prompt:
(Pdb)

-- control passed back to cafykit from netmiko
